### PR TITLE
Confirm Cargo Version matches Tag Version in release CI/CD workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+
       - name: Get version from cargo.toml
         uses: SebRollen/toml-action@v1.0.0
         id: cargo_version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           field: 'package.version'
 
       - name: Verify package version is equal to tag version
-        if: ${{ "v" + steps.cargo_version.outputs.value != github.ref}}
+        if: ${{ format('v{0}', steps.cargo_version.outputs.value) != github.ref}}
         run: "exit 1"
 
       - name: Create Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Verify package version is equal to tag version
         if: ${{ "v" + steps.cargo_version.outputs.value != github.ref}}
         run: | 
-        echo "${{ steps.cargo_version.outputs.value }}"
-        echo "${{ github.ref }}"
+        echo ${{ steps.cargo_version.outputs.value }}
+        echo ${{ github.ref }}
         echo "Cargo version did not match tag version! Termianting..."
         exit 1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,15 +24,16 @@ jobs:
 
       - name: Get the tag of current release
         id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF#refs/tags/v)
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+
 
       - name: Verify package version is equal to tag version
-        if: ${{ format('v{0}', steps.cargo_version.outputs.value) != steps.get_version.outputs.VERSION }}
+        if: ${{ steps.cargo_version.outputs.value != steps.get_version.outputs.VERSION }}
         run: |
-          echo "${{ format('v{0}', steps.cargo_version.outputs.value) }}"
+          echo "${{ steps.cargo_version.outputs.value }}"
           echo "${{ steps.get_version.outputs.VERSION }}"
           exit 1
-
+          
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           field: 'package.version'
 
       - name: Verify package version is equal to tag version
-        if: "!contains("v" + steps.read_toml.outputs.value, github.ref"
+        if: "!contains(steps.read_toml.outputs.value, github.ref"
         run: exit 1
 
       - name: Create Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: SebRollen/toml-action@v1.0.0
         id: cargo_version
         with:
-          file: 'cargo.toml'
+          file: 'Cargo.toml'
           field: 'package.version'
 
       - name: Verify package version is equal to tag version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-
       - name: Get version from cargo.toml
         uses: SebRollen/toml-action@v1.0.0
         id: cargo_version
@@ -22,7 +21,7 @@ jobs:
       - name: Verify package version is equal to tag version
         if: "!contains(steps.read_toml.outputs.value, github.ref"
         run: exit 1
-        
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get the tag of current release
         id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF#refs/tags/v)
 
       - name: Verify package version is equal to tag version
         if: ${{ format('v{0}', steps.cargo_version.outputs.value) != steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
       - name: Verify package version is equal to tag version
         if: ${{ format('v{0}', steps.cargo_version.outputs.value) != github.ref}}
         run: "exit 1"
+        run: "echo ${{ format('v{0}', steps.cargo_version.outputs.value) }}"
+        run: "echo ${{ github.ref }}"
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,8 +23,12 @@ jobs:
           field: 'package.version'
 
       - name: Verify package version is equal to tag version
-        if: "!contains(steps.read_toml.outputs.value, github.ref)"
-        run: exit 1
+        if: ${{ "v" + steps.cargo_version.outputs.value != github.ref}}
+        run: | 
+        echo "${{ steps.cargo_version.outputs.value }}"
+        echo "${{ github.ref }}"
+        echo "Cargo version did not match tag version! Termianting..."
+        exit 1
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+  branches: 
+    - main
     tags: "v*"
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-  branches: "main"
+    branches: "main"
     tags: "v*"
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           field: 'package.version'
 
       - name: Verify package version is equal to tag version
-        if: "!contains(steps.read_toml.outputs.value, github.ref"
+        if: "!contains(steps.read_toml.outputs.value, github.ref)"
         run: exit 1
 
       - name: Create Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,11 +22,15 @@ jobs:
           file: 'Cargo.toml'
           field: 'package.version'
 
+      - name: Get the tag of current release
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
       - name: Verify package version is equal to tag version
-        if: ${{ format('v{0}', steps.cargo_version.outputs.value) != github.ref}}
+        if: ${{ format('v{0}', steps.cargo_version.outputs.value) != steps.get_version.outputs.VERSION }}
         run: |
           echo "${{ format('v{0}', steps.cargo_version.outputs.value) }}"
-          echo "${{ github.ref }}"
+          echo "${{ steps.get_version.outputs.VERSION }}"
           exit 1
 
       - name: Create Release
@@ -35,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
           release_name: ${{ github.ref }}
           draft: true
           prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,9 +24,10 @@ jobs:
 
       - name: Verify package version is equal to tag version
         if: ${{ format('v{0}', steps.cargo_version.outputs.value) != github.ref}}
-        run: "exit 1"
-        run: "echo ${{ format('v{0}', steps.cargo_version.outputs.value) }}"
-        run: "echo ${{ github.ref }}"
+        run: |
+          echo "${{ format('v{0}', steps.cargo_version.outputs.value) }}"
+          echo "${{ github.ref }}"
+          exit 1
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           field: 'package.version'
 
       - name: Verify package version is equal to tag version
-        if: "!contains(steps.read_toml.outputs.value, github.ref"
+        if: "!contains("v" + steps.read_toml.outputs.value, github.ref"
         run: exit 1
 
       - name: Create Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,7 @@ jobs:
 
       - name: Verify package version is equal to tag version
         if: ${{ "v" + steps.cargo_version.outputs.value != github.ref}}
-        run: | 
-        echo ${{ steps.cargo_version.outputs.value }}
-        echo ${{ github.ref }}
-        echo "Cargo version did not match tag version! Termianting..."
-        exit 1
+        run: "exit 1"
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,7 @@ name: Release
 
 on:
   push:
-  branches: 
-    - main
+  branches: "main"
     tags: "v*"
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,18 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+
+      - name: Get version from cargo.toml
+        uses: SebRollen/toml-action@v1.0.0
+        id: cargo_version
+        with:
+          file: 'cargo.toml'
+          field: 'package.version'
+
+      - name: Verify package version is equal to tag version
+        if: "!contains(steps.read_toml.outputs.value, github.ref"
+        run: exit 1
+        
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbxcloud"
-version = "0.1.0-alpha.9" 
+version = "0.1.0-alpha.10" 
 description = "CLI for the Roblox Open Cloud APIs"
 authors = ["Stephen Leitnick"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbxcloud"
-version = "0.1.0-alpha.10" 
+version = "0.1.0-alpha.11" 
 description = "CLI for the Roblox Open Cloud APIs"
 authors = ["Stephen Leitnick"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbxcloud"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8" 
 description = "CLI for the Roblox Open Cloud APIs"
 authors = ["Stephen Leitnick"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbxcloud"
-version = "0.1.0-alpha.8" 
+version = "0.1.0-alpha.9" 
 description = "CLI for the Roblox Open Cloud APIs"
 authors = ["Stephen Leitnick"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbxcloud"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 description = "CLI for the Roblox Open Cloud APIs"
 authors = ["Stephen Leitnick"]
 license = "MIT"


### PR DESCRIPTION
Resolves #3 

Done:
* Find the cargo version from the `Cargo.toml` file.
* Add a `v` to the version within the workflow.
* Cancel the workflow if the two do not match up.

Todo:
* Figure out why `github.ref` is not returning the current tag.
* Complete the semi-automation of releases in the CI workflow. 

If I can figure out why I cannot get the tag using `github.ref`, everything else should be pretty much done from there. 

Thanks!