### PR TITLE
Wrap AssetGetOperation fields done and response in Option

### DIFF
--- a/src/rbx/assets.rs
+++ b/src/rbx/assets.rs
@@ -92,8 +92,8 @@ pub struct ProtobufAny {
 #[serde(rename_all = "camelCase")]
 pub struct AssetGetOperation {
     pub path: String,
-    pub done: bool,
-    pub response: AssetGetOperationResponse,
+    pub done: Option<bool>,
+    pub response: Option<AssetGetOperationResponse>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
The `done` and `response` fields are sometimes absent from asset get operations for recently created assets, resulting in errors like this:
```
ReqwestError(
    reqwest::Error {
        kind: Decode,
        source: Error("missing field `done`", line: 1, column: 61),
    },
)
```

When this happens, it usually takes a few seconds before these fields are present in responses. Here's some output from me retrying this endpoint (now using optional `done` and `response`) directly after creating an asset:
```
[2023-04-18 17:08:28] AssetGetOperation {
[2023-04-18 17:08:28]     path: "operations/43db82d3-ee5e-4df9-986b-dc833ac3d3c1",
[2023-04-18 17:08:28]     done: None,
[2023-04-18 17:08:28]     response: None,
[2023-04-18 17:08:28] }
[2023-04-18 17:08:29] AssetGetOperation {
[2023-04-18 17:08:29]     path: "operations/43db82d3-ee5e-4df9-986b-dc833ac3d3c1",
[2023-04-18 17:08:29]     done: None,
[2023-04-18 17:08:29]     response: None,
[2023-04-18 17:08:29] }
[2023-04-18 17:08:30] AssetGetOperation {
[2023-04-18 17:08:30]     path: "operations/43db82d3-ee5e-4df9-986b-dc833ac3d3c1",
[2023-04-18 17:08:30]     done: None,
[2023-04-18 17:08:30]     response: None,
[2023-04-18 17:08:30] }
[2023-04-18 17:08:31] AssetGetOperation {
[2023-04-18 17:08:31]     path: "operations/43db82d3-ee5e-4df9-986b-dc833ac3d3c1",
[2023-04-18 17:08:31]     done: None,
[2023-04-18 17:08:31]     response: None,
[2023-04-18 17:08:31] }
[2023-04-18 17:08:33] AssetGetOperation {
[2023-04-18 17:08:33]     path: "operations/43db82d3-ee5e-4df9-986b-dc833ac3d3c1",
[2023-04-18 17:08:33]     done: Some(
[2023-04-18 17:08:33]         true,
[2023-04-18 17:08:33]     ),
[2023-04-18 17:08:33]     response: Some(
[2023-04-18 17:08:33]         AssetGetOperationResponse {
[2023-04-18 17:08:33]             response_type: "type.googleapis.com/roblox.open_cloud.assets.v1.Asset",
[2023-04-18 17:08:33]             path: "assets/13176690446",
[2023-04-18 17:08:33]             revision_id: "1",
[2023-04-18 17:08:33]             revision_create_time: "2023-04-19T00:08:31.745079700Z",
[2023-04-18 17:08:33]             asset_id: "13176690446",
[2023-04-18 17:08:33]             display_name: "model",
[2023-04-18 17:08:33]             description: "",
[2023-04-18 17:08:33]             asset_type: "ASSET_TYPE_MODEL",
[2023-04-18 17:08:33]             creation_context: AssetCreationContext {
[2023-04-18 17:08:33]                 creator: User(
[2023-04-18 17:08:33]                     AssetUserCreator {
[2023-04-18 17:08:33]                         user_id: "5701242",
[2023-04-18 17:08:33]                     },
[2023-04-18 17:08:33]                 ),
[2023-04-18 17:08:33]                 expected_price: None,
[2023-04-18 17:08:33]             },
[2023-04-18 17:08:33]         },
[2023-04-18 17:08:33]     ),
[2023-04-18 17:08:33] }
```

I've only observed this behavior for fbx models. I don't know if it can occur with audio or images, and I'm not sure if it's a bug in the API, but I think rbxcloud should avoid just falling over here!