### PR TITLE
Remove @type field from AssetGetOperationResponse

### DIFF
--- a/src/rbx/assets.rs
+++ b/src/rbx/assets.rs
@@ -99,8 +99,6 @@ pub struct AssetGetOperation {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetGetOperationResponse {
-    #[serde(rename = "@type")]
-    pub response_type: String,
     pub path: String,
     pub revision_id: String,
     pub revision_create_time: String,


### PR DESCRIPTION
This field is no longer present in asset get operation responses and currently causes rbxcloud to error when using this API, making it unusable 